### PR TITLE
updated heavy water separation typo

### DIFF
--- a/bobplates/locale/en/bobplates.cfg
+++ b/bobplates/locale/en/bobplates.cfg
@@ -207,7 +207,7 @@ bob-petroleum-gas-cracking=Petroleum gas cracking to hydrogen
 bob-solid-fuel-from-hydrogen=Solid fuel from hydrogen
 bob-cobalt-oxide-from-copper=Advanced copper processing with cobalt oxide
 bob-silver-from-lead=Advanced lead processing with silver ore
-bob-heavy-water=Heavy water seperation
+bob-heavy-water=Heavy water separation
 bob-sodium-hydroxide-sink=Sodium hydroxide to steam
 bob-void=Void __1__
 


### PR DESCRIPTION
I've came across a typo while creating some deuterium - "heavy water seperation" instead of separation. This should fix it.