### PR TITLE
Sync "bob-resource" subgroup

### DIFF
--- a/bobelectronics/prototypes/category.lua
+++ b/bobelectronics/prototypes/category.lua
@@ -24,3 +24,8 @@ data:extend({
     order = "e-a4",
   },
 })
+
+if data.raw["item-group"]["bob-resource-products"] then
+  data.raw["item-subgroup"]["bob-resource"].group = "bob-resource-products"
+  data.raw["item-subgroup"]["bob-resource"].order = "b-b"
+end


### PR DESCRIPTION
This brings the "bob-resource" subgroup in bobelectronics in line with the other two places where it is defined. Those being bobplates and bobwarfare.

In the case where you have bobplates and bobelectronics active, but not bobwarfare, this subgroup would be moved to an odd place within the Intermediates tab instead of the Materials tab because the bobelectronics definition overrides the bobplates definition due to coming later.