### PR TITLE
Enemies category fix

### DIFF
--- a/bobenemies/prototypes/categories.lua
+++ b/bobenemies/prototypes/categories.lua
@@ -76,6 +76,7 @@ table.insert(
 )
 
 table.insert(data.raw["utility-constants"].default.default_trigger_target_mask_by_type.unit, "not-fire-unit")
+table.insert(data.raw["utility-constants"].default.default_trigger_target_mask_by_type.unit, "not-electric-unit")
 table.insert(
   data.raw["utility-constants"].default.default_trigger_target_mask_by_type["capture-robot"],
   "not-fire-unit"


### PR DESCRIPTION
For some reason, the "not-electric-unit" category wasn't being added to the default trigger target mask for units. This will fix the issue.