### PR TITLE
Classic beacon fix

### DIFF
--- a/bobmodules/data-updates.lua
+++ b/bobmodules/data-updates.lua
@@ -4,6 +4,20 @@ require("prototypes.recipe.module-updates")
 require("prototypes.recipe.module-merged-updates")
 require("prototypes.technology.module-updates")
 
+if mods["classic-beacon"] then
+  require("__classic-beacon__.prototypes.beacon")
+  data.raw.item["bob-beacon-2"].icon = data.raw.item["beacon"].icon
+  data.raw.item["bob-beacon-3"].icon = data.raw.item["beacon"].icon
+  data.raw.beacon["bob-beacon-2"].icon = data.raw.item["beacon"].icon
+  data.raw.beacon["bob-beacon-3"].icon = data.raw.item["beacon"].icon
+  data.raw.beacon["bob-beacon-2"].graphics_set = data.raw.beacon["beacon"].graphics_set
+  data.raw.beacon["bob-beacon-3"].graphics_set = data.raw.beacon["beacon"].graphics_set
+  data.raw.technology["effect-transmission-2"].icon = data.raw.technology["effect-transmission"].icon
+  data.raw.technology["effect-transmission-3"].icon = data.raw.technology["effect-transmission"].icon
+  data.raw.technology["effect-transmission-2"].icon_size = 128
+  data.raw.technology["effect-transmission-3"].icon_size = 128
+end
+
 if mods["quality"] then
   bobmods.lib.recipe.update_recycling_recipe({
     "bob-module-contact",

--- a/bobmodules/prototypes/beacon.lua
+++ b/bobmodules/prototypes/beacon.lua
@@ -160,6 +160,8 @@ if mods["classic-beacon"] then
   data.raw.beacon["beacon"].icon = "__base__/graphics/icons/beacon.png"
   data.raw.beacon["bob-beacon-2"].icon = "__base__/graphics/icons/beacon.png"
   data.raw.beacon["bob-beacon-3"].icon = "__base__/graphics/icons/beacon.png"
+  data.raw.technology["effect-transmission"].icon = "__base__/graphics/technology/effect-transmission.png"
+  data.raw.technology["effect-transmission"].icon_size = 256
 end
 
 if mods["space-age"] then

--- a/bobmodules/prototypes/beacon.lua
+++ b/bobmodules/prototypes/beacon.lua
@@ -155,6 +155,13 @@ data:extend({
 
 data.raw.beacon["beacon"].next_upgrade = "bob-beacon-2"
 
+if mods["classic-beacon"] then
+  data.raw.item["beacon"].icon = "__base__/graphics/icons/beacon.png"
+  data.raw.beacon["beacon"].icon = "__base__/graphics/icons/beacon.png"
+  data.raw.beacon["bob-beacon-2"].icon = "__base__/graphics/icons/beacon.png"
+  data.raw.beacon["bob-beacon-3"].icon = "__base__/graphics/icons/beacon.png"
+end
+
 if mods["space-age"] then
   bobmods.lib.recipe.add_additional_category("bob-beacon-2", "electromagnetics")
   bobmods.lib.recipe.add_additional_category("bob-beacon-3", "electromagnetics")

--- a/bobmodules/prototypes/beacon.lua
+++ b/bobmodules/prototypes/beacon.lua
@@ -155,15 +155,6 @@ data:extend({
 
 data.raw.beacon["beacon"].next_upgrade = "bob-beacon-2"
 
-if mods["classic-beacon"] then
-  data.raw.item["beacon"].icon = "__base__/graphics/icons/beacon.png"
-  data.raw.beacon["beacon"].icon = "__base__/graphics/icons/beacon.png"
-  data.raw.beacon["bob-beacon-2"].icon = "__base__/graphics/icons/beacon.png"
-  data.raw.beacon["bob-beacon-3"].icon = "__base__/graphics/icons/beacon.png"
-  data.raw.technology["effect-transmission"].icon = "__base__/graphics/technology/effect-transmission.png"
-  data.raw.technology["effect-transmission"].icon_size = 256
-end
-
 if mods["space-age"] then
   bobmods.lib.recipe.add_additional_category("bob-beacon-2", "electromagnetics")
   bobmods.lib.recipe.add_additional_category("bob-beacon-3", "electromagnetics")

--- a/bobmodules/prototypes/entity/beacon-module-slots.lua
+++ b/bobmodules/prototypes/entity/beacon-module-slots.lua
@@ -431,6 +431,22 @@ for _, name in pairs(beacons) do
   ---@type data.BeaconPrototype
   local beacon = data.raw["beacon"][name]
 
+  if not beacon.graphics_set.module_visualisations then
+    --Restore module_visualisations if removed by Classic Beacons or other such mods
+    beacon.graphics_set.module_visualisations = {
+      {
+        art_style = "vanilla",
+        use_for_empty_slots = true,
+        tier_offset = 0,
+        slots = {
+          create_vanilla_module_slot_1({ 0, 0 }),
+          create_vanilla_module_slot_2({ 0, 0 }),
+          append_pad_layer(create_vanilla_module_slot_2({ 0, 0 })),
+        },
+      },
+    }
+  end
+
   if beacon.module_slots == 2 then
     -- 5 light modules
     table.insert(beacon.graphics_set.module_visualisations, {


### PR DESCRIPTION
Resolves #527 

Adds a safety workaround to prevent Classic Beacons and Bobmodules from failing to load together. Then does the Classic Beacons graphics changes in the data-updates stage, applying it to all beacons instead of just the first.