### PR TITLE
Fix inserter next_upgrades

### DIFF
--- a/boblogistics/changelog.txt
+++ b/boblogistics/changelog.txt
@@ -3,6 +3,8 @@ Version: 2.0.7
 Date: ???
   Changes:
     - Reduced charge approach distance for robochests. Robots waiting to charge will now wait closer to the robochest. #533
+  Bugfixes:
+    - Fixed next_upgrade for Steam powered inserter and Ultimate inserter #542
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.6
 Date: 18. 01. 2026

--- a/boblogistics/prototypes/entity/inserter.lua
+++ b/boblogistics/prototypes/entity/inserter.lua
@@ -64,6 +64,8 @@ local inserter = {
   },
 }
 
+data.raw.inserter["burner-inserter"].next_upgrade = "inserter"
+
 data:extend({
   util.merge({
     data.raw.inserter["inserter"],
@@ -80,6 +82,7 @@ data:extend({
     },
   }),
 })
+data.raw.inserter["bob-steam-inserter"].next_upgrade = nil
 data.raw.inserter["bob-steam-inserter"].hand_base_picture = inserter.graphics.white.hand_base_picture()
 data.raw.inserter["bob-steam-inserter"].hand_closed_picture = inserter.graphics.white.hand_closed_picture()
 data.raw.inserter["bob-steam-inserter"].hand_open_picture = inserter.graphics.white.hand_open_picture()
@@ -297,6 +300,7 @@ if settings.startup["bobmods-logistics-inserteroverhaul"].value == true then
   data.raw.inserter["fast-inserter"].localised_name = { "entity-name.bob-express-inserter" }
   data.raw.inserter["bulk-inserter"].localised_name = { "entity-name.bob-express-bulk-inserter" }
 
+  data.raw.inserter["bob-express-inserter"].next_upgrade = "bob-express-bulk-inserter"
   data.raw.inserter["bob-express-inserter"].localised_name = { "entity-name.bob-ultimate-inserter" }
   data.raw.inserter["bob-express-inserter"].icon = "__boblogistics__/graphics/icons/inserter/green-inserter.png"
   data.raw.inserter["bob-express-inserter"].icon_size = 32

--- a/boblogistics/prototypes/entity/inserter.lua
+++ b/boblogistics/prototypes/entity/inserter.lua
@@ -64,8 +64,6 @@ local inserter = {
   },
 }
 
-data.raw.inserter["burner-inserter"].next_upgrade = "inserter"
-
 data:extend({
   util.merge({
     data.raw.inserter["inserter"],


### PR DESCRIPTION
Makes burner-inserter upgrade into yellow inserter.

Makes bob-steam-inserter upgrade into nothing. It's kind of its own beast, and its variable speed makes it hard to determine what it ought to upgrade into. Incidentally, setting its next_upgrade to nil has to be done after the util.merge because otherwise the game will just keep the previous value.

Makes (green)bob-express-inserter upgrade into bob-express-bulk-inserter if Inserter Overhaul is enabled. Previously, it wanted to upgrade into the (blue in this setting)bulk-inserter, which makes sense when Inserter Overhaul is off, but not when it's on. Could also go with no upgrade for it, since it's the top-tier non-bulk inserter.