### PR TITLE
Fusion reactor migration fix

### DIFF
--- a/bobenemies/prototypes/functions.lua
+++ b/bobenemies/prototypes/functions.lua
@@ -693,11 +693,6 @@ function bobmods.enemies.new_biter(inputs)
     flags = { "placeable-neutral", "placeable-off-grid", "building-direction-8-way", "not-on-map" },
   })
 
-  table.remove(corpse_prototype.animation.layers)
-  corpse_prototype.animation_render_layer = "corpse"
-  corpse_prototype.final_render_layer = "corpse"
-  corpse_prototype.use_decay_layer = false
-  
   data:extend({ biter_prototype, corpse_prototype })
 end
 
@@ -1346,11 +1341,6 @@ function bobmods.enemies.new_spitter(inputs)
     order = "c[corpse]-" .. inputs.order,
     flags = { "placeable-neutral", "placeable-off-grid", "building-direction-8-way", "not-on-map" },
   })
-
-  table.remove(corpse_prototype.animation.layers)
-  corpse_prototype.animation_render_layer = "corpse"
-  corpse_prototype.final_render_layer = "corpse"
-  corpse_prototype.use_decay_layer = false
 
   if not inputs.no_acid_stream == true then
     bobmods.enemies.acid_stream(inputs, final_scale)
@@ -2825,10 +2815,6 @@ function bobmods.enemies.new_worm(inputs)
   worm_corpse_2.icon = "__base__/graphics/icons/big-worm-corpse.png"
   worm_corpse_1.localised_name = { "entity-name.bob-enemies-corpse" }
   worm_corpse_2.localised_name = { "entity-name.bob-enemies-corpse" }
-  worm_corpse_1.animation_render_layer = "corpse"
-  worm_corpse_2.animation_render_layer = "corpse"
-  worm_corpse_1.final_render_layer = "corpse"
-  worm_corpse_2.final_render_layer = "corpse"
 
   if inputs.tint2 then
     table.insert(
@@ -3184,18 +3170,8 @@ function bobmods.enemies.new_spawner(inputs)
       spawner_decay_animation(3, inputs.tint),
     },
     decay_frame_transition_duration = 360,
-    animation_render_layer = "corpse",
-    final_render_layer = "corpse",
+    final_render_layer = "lower-object-above-shadow",
   }
-
-  table.remove(spawner_corpse.animation[1].layers)
-  table.remove(spawner_corpse.animation[2].layers)
-  table.remove(spawner_corpse.animation[3].layers)
-  table.remove(spawner_corpse.animation[4].layers)
-  table.remove(spawner_corpse.decay_animation[1].layers)
-  table.remove(spawner_corpse.decay_animation[2].layers)
-  table.remove(spawner_corpse.decay_animation[3].layers)
-  table.remove(spawner_corpse.decay_animation[4].layers)
 
   if inputs.tint2 then
     table.insert(

--- a/bobenemies/prototypes/functions.lua
+++ b/bobenemies/prototypes/functions.lua
@@ -693,6 +693,11 @@ function bobmods.enemies.new_biter(inputs)
     flags = { "placeable-neutral", "placeable-off-grid", "building-direction-8-way", "not-on-map" },
   })
 
+  table.remove(corpse_prototype.animation.layers)
+  corpse_prototype.animation_render_layer = "corpse"
+  corpse_prototype.final_render_layer = "corpse"
+  corpse_prototype.use_decay_layer = false
+  
   data:extend({ biter_prototype, corpse_prototype })
 end
 
@@ -1341,6 +1346,11 @@ function bobmods.enemies.new_spitter(inputs)
     order = "c[corpse]-" .. inputs.order,
     flags = { "placeable-neutral", "placeable-off-grid", "building-direction-8-way", "not-on-map" },
   })
+
+  table.remove(corpse_prototype.animation.layers)
+  corpse_prototype.animation_render_layer = "corpse"
+  corpse_prototype.final_render_layer = "corpse"
+  corpse_prototype.use_decay_layer = false
 
   if not inputs.no_acid_stream == true then
     bobmods.enemies.acid_stream(inputs, final_scale)
@@ -2815,6 +2825,10 @@ function bobmods.enemies.new_worm(inputs)
   worm_corpse_2.icon = "__base__/graphics/icons/big-worm-corpse.png"
   worm_corpse_1.localised_name = { "entity-name.bob-enemies-corpse" }
   worm_corpse_2.localised_name = { "entity-name.bob-enemies-corpse" }
+  worm_corpse_1.animation_render_layer = "corpse"
+  worm_corpse_2.animation_render_layer = "corpse"
+  worm_corpse_1.final_render_layer = "corpse"
+  worm_corpse_2.final_render_layer = "corpse"
 
   if inputs.tint2 then
     table.insert(
@@ -3170,8 +3184,18 @@ function bobmods.enemies.new_spawner(inputs)
       spawner_decay_animation(3, inputs.tint),
     },
     decay_frame_transition_duration = 360,
-    final_render_layer = "lower-object-above-shadow",
+    animation_render_layer = "corpse",
+    final_render_layer = "corpse",
   }
+
+  table.remove(spawner_corpse.animation[1].layers)
+  table.remove(spawner_corpse.animation[2].layers)
+  table.remove(spawner_corpse.animation[3].layers)
+  table.remove(spawner_corpse.animation[4].layers)
+  table.remove(spawner_corpse.decay_animation[1].layers)
+  table.remove(spawner_corpse.decay_animation[2].layers)
+  table.remove(spawner_corpse.decay_animation[3].layers)
+  table.remove(spawner_corpse.decay_animation[4].layers)
 
   if inputs.tint2 then
     table.insert(

--- a/bobequipment/migrations/bobequipment_2.0.0.json
+++ b/bobequipment/migrations/bobequipment_2.0.0.json
@@ -91,7 +91,6 @@
     ["energy-shield-mk6-equipment", "bob-energy-shield-mk6-equipment"],
     ["exoskeleton-equipment-2", "bob-exoskeleton-equipment-2"],
     ["exoskeleton-equipment-3", "bob-exoskeleton-equipment-3"],
-    ["fusion-reactor-equipment", "fission-reactor-equipment"],
     ["fusion-reactor-equipment-2", "bob-fission-reactor-equipment-2"],
     ["fusion-reactor-equipment-3", "bob-fission-reactor-equipment-3"],
     ["fusion-reactor-equipment-4", "bob-fission-reactor-equipment-4"],
@@ -124,7 +123,6 @@
   [
     ["exoskeleton-equipment-2", "bob-exoskeleton-equipment-2"],
     ["exoskeleton-equipment-3", "bob-exoskeleton-equipment-3"],
-    ["fusion-reactor-equipment", "fission-reactor-equipment"],
     ["fusion-reactor-equipment-2", "bob-fission-reactor-equipment-2"],
     ["fusion-reactor-equipment-3", "bob-fission-reactor-equipment-3"],
     ["fusion-reactor-equipment-4", "bob-fission-reactor-equipment-4"],


### PR DESCRIPTION
Removes migration of fusion-reactor-equipment -> fission-reactor-equipment for recipe and technology. This causes problems because Space Age has both.