### PR TITLE
Fix bob-silicon-wafer name in solar panel recipe updates

### DIFF
--- a/boblibrary/recipe-functions.lua
+++ b/boblibrary/recipe-functions.lua
@@ -124,14 +124,19 @@ function bobmods.lib.recipe.add_ingredient(recipe, item_in)
     and type(item) == "table"
     and bobmods.lib.item.get_type(item.name)
   then
-    if data.raw.recipe[recipe].ingredients then
-      bobmods.lib.item.add(data.raw.recipe[recipe].ingredients, item)
+    if not data.raw.recipe[recipe].ingredients then
+      data.raw.recipe[recipe].ingredients = {}
     end
-  else
-    if not (type(recipe) == "string" and data.raw.recipe[recipe]) then
-      log(debug.traceback())
-      bobmods.lib.error.recipe(recipe)
-    end
+    bobmods.lib.item.add(data.raw.recipe[recipe].ingredients, item)
+  elseif not (type(recipe) == "string" and data.raw.recipe[recipe]) then
+    log(debug.traceback())
+    bobmods.lib.error.recipe(recipe)
+  elseif type(item) == "string" then
+    log(debug.traceback())
+    bobmods.lib.error(item)
+  elseif type(item) == "table" then
+    log(debug.traceback())
+    bobmods.lib.error.item(item.name)
   end
 end
 

--- a/bobpower/changelog.txt
+++ b/bobpower/changelog.txt
@@ -1,6 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.5
 Date: ???
+  Bugfixes:
+    - Fixed solar panel recipes missing Silicon wafers (with Bob's MCI mod) #591
   Changes:
     - Reduced the time that heat sources take to get up to temperature #529
     - Disallowed certain entities in space #551

--- a/bobpower/prototypes/recipe/solar-panels-updates.lua
+++ b/bobpower/prototypes/recipe/solar-panels-updates.lua
@@ -103,17 +103,17 @@ if settings.startup["bobmods-power-solar"].value == true then
     bobmods.lib.tech.add_prerequisite("bob-solar-energy-3", "bob-advanced-processing-unit")
   end
 
-  if data.raw.item["silicon-wafer"] then
-    bobmods.lib.recipe.add_ingredient("bob-solar-panel-small", { type = "item", name = "silicon-wafer", amount = 16 })
-    bobmods.lib.recipe.add_ingredient("solar-panel", { type = "item", name = "silicon-wafer", amount = 36 })
-    bobmods.lib.recipe.add_ingredient("bob-solar-panel-large", { type = "item", name = "silicon-wafer", amount = 64 })
+  if data.raw.item["bob-silicon-wafer"] then
+    bobmods.lib.recipe.add_ingredient("bob-solar-panel-small", { type = "item", name = "bob-silicon-wafer", amount = 16 })
+    bobmods.lib.recipe.add_ingredient("solar-panel", { type = "item", name = "bob-silicon-wafer", amount = 36 })
+    bobmods.lib.recipe.add_ingredient("bob-solar-panel-large", { type = "item", name = "bob-silicon-wafer", amount = 64 })
     bobmods.lib.tech.add_prerequisite("solar-energy", "bob-silicon-processing")
-    bobmods.lib.recipe.add_ingredient("bob-solar-panel-small-2", { type = "item", name = "silicon-wafer", amount = 12 })
-    bobmods.lib.recipe.add_ingredient("bob-solar-panel-2", { type = "item", name = "silicon-wafer", amount = 27 })
-    bobmods.lib.recipe.add_ingredient("bob-solar-panel-large-2", { type = "item", name = "silicon-wafer", amount = 48 })
-    bobmods.lib.recipe.add_ingredient("bob-solar-panel-small-3", { type = "item", name = "silicon-wafer", amount = 8 })
-    bobmods.lib.recipe.add_ingredient("bob-solar-panel-3", { type = "item", name = "silicon-wafer", amount = 18 })
-    bobmods.lib.recipe.add_ingredient("bob-solar-panel-large-3", { type = "item", name = "silicon-wafer", amount = 32 })
+    bobmods.lib.recipe.add_ingredient("bob-solar-panel-small-2", { type = "item", name = "bob-silicon-wafer", amount = 12 })
+    bobmods.lib.recipe.add_ingredient("bob-solar-panel-2", { type = "item", name = "bob-silicon-wafer", amount = 27 })
+    bobmods.lib.recipe.add_ingredient("bob-solar-panel-large-2", { type = "item", name = "bob-silicon-wafer", amount = 48 })
+    bobmods.lib.recipe.add_ingredient("bob-solar-panel-small-3", { type = "item", name = "bob-silicon-wafer", amount = 8 })
+    bobmods.lib.recipe.add_ingredient("bob-solar-panel-3", { type = "item", name = "bob-silicon-wafer", amount = 18 })
+    bobmods.lib.recipe.add_ingredient("bob-solar-panel-large-3", { type = "item", name = "bob-silicon-wafer", amount = 32 })
   elseif data.raw.item["bob-silicon-plate"] then
     bobmods.lib.recipe.add_ingredient(
       "bob-solar-panel-small",


### PR DESCRIPTION
Solar panels were supposed to have silicon wafers in their recipes (SP equipment does) but a name error ("silicon-wafer" when it should be "bob-silicon-wafer") broke this. Fixed now.